### PR TITLE
Truncate file through EOS using XRootD File interface

### DIFF
--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -381,9 +381,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
             if not status.ok:
                 raise OSError(f"Impossible to create file in EOS: {status.message}")
             if truncate or not await self._exists(path):
-                status, _ = await _async_wrap(f.truncate)(
-                    size=0, timeout=self.timeout
-                )
+                status, _ = await _async_wrap(f.truncate)(size=0, timeout=self.timeout)
             else:
                 len = await self._info(path)
                 status, _ = await _async_wrap(f.truncate)(
@@ -391,7 +389,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
                     timeout=self.timeout,
                 )
             f.close()
-        else: 
+        else:
             if truncate or not await self._exists(path):
                 status, _ = await _async_wrap(self._myclient.truncate)(
                     path, size=0, timeout=self.timeout


### PR DESCRIPTION
This (draft) PR targets the bug reported [here](https://github.com/CoffeaTeam/fsspec-xrootd/issues/68).
As explained in [this](https://github.com/xrootd/xrootd/issues/2304) other issue, the call to ```truncate``` is not supported in EOS, and the file has to exist before calling ```truncate```.
This can be done by using the ```File``` interface, as suggested [here](https://github.com/xrootd/xrootd/issues/2304#issuecomment-2273394816).

As the problem was spotted in uproot5, one solution could be to implement the wrapper there, but not having access to a ```XRootD.client.File``` object (since now uproot depends on ```fsspec```) prevents this.
This PR attempts to fix the problem by extending the behavior of the ```_touch``` function on the ```fsspec-xrootd``` side: the idea is to implement the necessary behavior only if we are trying to write a file on EOS.
Since I'm not familiar with the code, feedback is more than welcome, especially in case there are less invasive ways to do this and possible caveats of this procedure that I might not be considering.

It should also be noted that, for this to work, I think other changes would be needed either on the uproot or fsspec side: as in ```FileSink```, the ```fsspec.open``` function is called with mode ```w+b``` (see [here](https://github.com/scikit-hep/uproot5/blob/aa8b94f722982c6eb418f9f32273152039836fb2/src/uproot/sink/file.py#L55-L57)), the error in [here](https://github.com/fsspec/filesystem_spec/blob/master/fsspec/spec.py#L1850) is raised.