### PR TITLE
fix writing via XRootD (called from uproot)

### DIFF
--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -374,8 +374,10 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
     async def _touch(self, path: str, truncate: bool = False, **kwargs: Any) -> None:
         if truncate or not await self._exists(path):
             f = client.File()
-            status, _ = f.open(path, OpenFlags.DELETE)
-            f.close()
+            status, _ = await _async_wrap(f.open)(
+                path, OpenFlags.DELETE
+            )
+            await _async_wrap(f.close)()
             if not status.ok:
                 raise OSError(f"File not touched properly: {status.message}")
         else:

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -374,9 +374,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
     async def _touch(self, path: str, truncate: bool = False, **kwargs: Any) -> None:
         if truncate or not await self._exists(path):
             f = client.File()
-            status, _ = await _async_wrap(f.open)(
-                path, OpenFlags.DELETE
-            )
+            status, _ = await _async_wrap(f.open)(path, OpenFlags.DELETE)
             await _async_wrap(f.close)()
             if not status.ok:
                 raise OSError(f"File not touched properly: {status.message}")
@@ -999,12 +997,7 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
             raise ValueError("I/O operation on closed file.")
         if self.forced:
             raise ValueError("This file has been force-flushed, can only close")
-        status, _n = self._myFile.write(
-            data, 
-            self.loc,
-            len(data), 
-            timeout=self.timeout
-        )
+        status, _n = self._myFile.write(data, self.loc, len(data), timeout=self.timeout)
         self.loc += len(data)
         self.size = max(self.size, self.loc)
         if not status.ok:

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -374,9 +374,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
     async def _touch(self, path: str, truncate: bool = False, **kwargs: Any) -> None:
         if truncate or not await self._exists(path):
             f = client.File()
-            status, _ = await _async_wrap(f.open)(
-                path, OpenFlags.DELETE
-            )
+            status, _ = await _async_wrap(f.open)(path, OpenFlags.DELETE)
             await _async_wrap(f.close)()
             if not status.ok:
                 raise OSError(f"File not touched properly: {status.message}")
@@ -997,12 +995,7 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
             raise ValueError("I/O operation on closed file.")
         if self.forced:
             raise ValueError("This file has been force-flushed, can only close")
-        status, _n = self._myFile.write(
-            data, 
-            self.loc,
-            len(data), 
-            timeout=self.timeout
-        )
+        status, _n = self._myFile.write(data, self.loc, len(data), timeout=self.timeout)
         self.loc += len(data)
         self.size = max(self.size, self.loc)
         if not status.ok:

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -1029,7 +1029,7 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
             # don't even bother calling fetch
             return b""
         # for mypy
-        out = cast(bytes, self.cache.fetch(self.loc, self.loc + length))
+        out = cast(bytes, self.cache._fetch(self.loc, self.loc + length))
 
         self.loc += len(out)
         return out

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -758,8 +758,6 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
         from fsspec.core import caches
 
         self.timeout = fs.timeout
-        # by this point, mode will have a "b" in it
-        # update "+" mode removed for now since seek() is read only
         if mode == "r+b":
             self.mode = OpenFlags.UPDATE
         elif "x" in mode:

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -951,7 +951,7 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
             raise OSError(f"File did not close properly: {status.message}")
         self.closed = True
 
-    def seek(self, loc, whence=0):
+    def seek(self, loc: int, whence: int = 0) -> int:
         """Set current file location
 
         Parameters
@@ -975,11 +975,11 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
         self.loc = nloc
         return self.loc
 
-    def writable(self):
+    def writable(self) -> bool:
         """Whether opened for writing"""
         return self.mode in {"wb", "ab", "xb", "r+b"} and not self.closed
 
-    def write(self, data):
+    def write(self, data: bytes) -> int:
         """
         Write data to buffer.
 
@@ -1009,7 +1009,7 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
             raise OSError(f"File did not write properly: {status.message}")
         return len(data)
 
-    def read(self, length=-1):
+    def read(self, length: int = -1) -> bytes:
         """
         Return data from cache, or fetch pieces as necessary
 

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -856,6 +856,8 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
             self.cache = caches[cache_type](
                 self.blocksize, self._fetch_range, self.size, **cache_options
             )
+        if "a" in mode:
+            self.loc = self.size
 
     def _locate_sources(self, logical_filename: str) -> list[str]:
         """Find hosts that have the desired file.

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -190,16 +190,16 @@ def test_write_rpb_fsspec(localserver, clear_server):
     filename = "test.bin"
     fs.touch(localpath + "/" + filename)
     with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
-        f.write(b'Hello, this is a test file for r+b mode.')
+        f.write(b"Hello, this is a test file for r+b mode.")
         f.flush()
     with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
-        assert f.read() == b'Hello, this is a test file for r+b mode.'
+        assert f.read() == b"Hello, this is a test file for r+b mode."
     with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
-        f.seek(len(b'Hello, this is a '))
-        f.write(b'REPLACED ')
+        f.seek(len(b"Hello, this is a "))
+        f.write(b"REPLACED ")
         f.flush()
     with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
-        assert f.read() == b'Hello, this is a REPLACED  for r+b mode.'
+        assert f.read() == b"Hello, this is a REPLACED  for r+b mode."
 
 
 @pytest.mark.parametrize("start, end", [(None, None), (None, 10), (1, None), (1, 10)])

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -183,6 +183,25 @@ def test_write_fsspec(localserver, clear_server):
         assert f.read() == TESTDATA1
 
 
+def test_write_rpb_fsspec(localserver, clear_server):
+    """Test writing with r+b as in uproot"""
+    remoteurl, localpath = localserver
+    fs, _ = fsspec.core.url_to_fs(remoteurl)
+    filename = "test.bin"
+    fs.touch(localpath + "/" + filename)
+    with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
+        f.write(b'Hello, this is a test file for r+b mode.')
+        f.flush()
+    with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
+        assert f.read() == b'Hello, this is a test file for r+b mode.'
+    with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
+        f.seek(len(b'Hello, this is a '))
+        f.write(b'REPLACED ')
+        f.flush()
+    with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
+        assert f.read() == b'Hello, this is a REPLACED  for r+b mode.'
+
+
 @pytest.mark.parametrize("start, end", [(None, None), (None, 10), (1, None), (1, 10)])
 def test_read_bytes_fsspec(localserver, clear_server, start, end):
     remoteurl, localpath = localserver


### PR DESCRIPTION
This PR fixes https://github.com/scikit-hep/uproot5/issues/1252.
Touching (and truncating) a file on EOS (implemented [here](https://github.com/scikit-hep/fsspec-xrootd/blob/main/src/fsspec_xrootd/xrootd.py#L376-L378)) needs the ```File``` interface in XRootD (as explained [here](https://github.com/xrootd/xrootd/issues/2304)).
After this, other changes were needed, especially to allow for the ```r+b``` mode used in uproot when opening a file. To do this, some functions such as ```seek```, ```write```, ```read``` where re-implemented instead of using the default ones in ```AbstractBufferedFile```.

Note: I believe some of these changes do not follow the logic that was originally implemented, so indications in this sense are much appreciated.