### PR TITLE
fix: Actually test using remote url instead of local fs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: python -m pip install .[test]
       - name: Test package
         run: |
-          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|FileNotFoundError|timeout|expired|connection|socket"
+          python -m pytest -vv tests --reruns 3 --reruns-delay 5 --only-rerun "(?i)OSError|FileNotFoundError|timeout|expired|connection|socket"
 
       - name: Run fsspec-xrootd tests from uproot latest release
         run: |

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -374,7 +374,8 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
     async def _touch(self, path: str, truncate: bool = False, **kwargs: Any) -> None:
         if truncate or not await self._exists(path):
             f = client.File()
-            status, _ = await _async_wrap(f.open)(path, OpenFlags.DELETE)
+            remote_path = self.unstrip_protocol(path)
+            status, _ = await _async_wrap(f.open)(remote_path, OpenFlags.DELETE)
             await _async_wrap(f.close)()
             if not status.ok:
                 raise OSError(f"File not touched properly: {status.message}")

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -212,8 +212,8 @@ def test_read_bytes_fsspec(localserver, clear_server, start, end):
     with open(localpath + "/testfile.txt", "w") as fout:
         fout.write(TESTDATA1)
 
-    fs, _ = fsspec.core.url_to_fs(remoteurl)
-    data = fs.read_bytes(localpath + "/testfile.txt", start=start, end=end)
+    fs, _, (prefix,) = fsspec.get_fs_token_paths(remoteurl)
+    data = fs.read_bytes(prefix + "/testfile.txt", start=start, end=end)
     assert data == TESTDATA1.encode("utf-8")[start:end]
 
 

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -189,10 +189,10 @@ def test_write_fsspec(localserver, clear_server):
 
 def test_write_rpb_fsspec(localserver, clear_server):
     """Test writing with r+b as in uproot"""
-    remoteurl, localpath = localserver
+    remoteurl, _ = localserver
     fs, _ = fsspec.core.url_to_fs(remoteurl)
     filename = "test.bin"
-    fs.touch(localpath + "/" + filename)
+    fs.touch(remoteurl + "/" + filename)
     with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
         f.write(b"Hello, this is a test file for r+b mode.")
         f.flush()

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -39,11 +39,12 @@ def localserver(tmpdir_factory):
     srvdir = tmpdir_factory.mktemp("srv")
     tempPath = os.path.join(srvdir, "Folder")
     os.mkdir(tempPath)
-    with open(os.path.join(srvdir, "xrd.cfg"), "w") as fout:
+    cfgfile = os.path.join(srvdir, "xrd.cfg")
+    with open(cfgfile, "w") as fout:
         fout.write("all.export /Folder\n")
         fout.write(f"oss.localroot {srvdir}\n")
     xrdexe = shutil.which("xrootd")
-    proc = subprocess.Popen([xrdexe, "-p", str(XROOTD_PORT), srvdir])
+    proc = subprocess.Popen([xrdexe, "-p", str(XROOTD_PORT), "-c", cfgfile])
     time.sleep(2)  # give it some startup
     yield "root://localhost//Folder", tempPath
     proc.terminate()

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -39,10 +39,13 @@ def localserver(tmpdir_factory):
     srvdir = tmpdir_factory.mktemp("srv")
     tempPath = os.path.join(srvdir, "Folder")
     os.mkdir(tempPath)
+    with open(os.path.join(srvdir, "xrd.cfg"), "w") as fout:
+        fout.write("all.export /Folder\n")
+        fout.write(f"oss.localroot {srvdir}\n")
     xrdexe = shutil.which("xrootd")
     proc = subprocess.Popen([xrdexe, "-p", str(XROOTD_PORT), srvdir])
     time.sleep(2)  # give it some startup
-    yield "root://localhost/" + str(tempPath), tempPath
+    yield "root://localhost//Folder", tempPath
     proc.terminate()
     proc.wait(timeout=10)
 

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -190,9 +190,9 @@ def test_write_fsspec(localserver, clear_server):
 def test_write_rpb_fsspec(localserver, clear_server):
     """Test writing with r+b as in uproot"""
     remoteurl, _ = localserver
-    fs, _ = fsspec.core.url_to_fs(remoteurl)
+    fs, _, (prefix,) = fsspec.get_fs_token_paths(remoteurl)
     filename = "test.bin"
-    fs.touch(remoteurl + "/" + filename)
+    fs.touch(prefix + "/" + filename)
     with fsspec.open(remoteurl + "/" + filename, "r+b") as f:
         f.write(b"Hello, this is a test file for r+b mode.")
         f.flush()

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -296,6 +296,16 @@ def test_touch_modified(localserver, clear_server):
     assert t1 < t2 and t2 < t3
 
 
+def test_touch_nonexistent(localserver, clear_server):
+    remoteurl, localpath = localserver
+    fs, token, path = fsspec.get_fs_token_paths(
+        remoteurl, "rt", storage_options={"listings_expiry_time": expiry_time}
+    )
+    filename = path[0] + "/non-existent-file.bin"
+    fs.touch(filename)
+    assert fs.exists(filename)
+
+
 def test_dir_cache(localserver, clear_server):
     remoteurl, localpath = localserver
     fs, token, path = fsspec.get_fs_token_paths(


### PR DESCRIPTION
We were getting false positives in our testing because `tempPath` in the testing harness was both the absolute local and remote path:
https://github.com/scikit-hep/fsspec-xrootd/blob/f0ea1eb169536df845f2d2259f58a6d20f7b37ff/tests/test_basicio.py#L45
So after removing the protocol-host-port, the remaining path strings are identical. The xrootd client silently works with local paths when there is no remote URL, so some functions appeared to work even though they did not actually go through the server. We now set up a config file for xrootd:
```
all.export /Folder
oss.localroot {srvdir}
```
so that e.g.
```
localpath  = '/tmp/pytest-of-runner/pytest-0/srv0/Folder'
remoteurl  = 'root://localhost//Folder'
```